### PR TITLE
Improve performance of /api/stops?query=main

### DIFF
--- a/app/apis/metro/importer.rb
+++ b/app/apis/metro/importer.rb
@@ -17,7 +17,12 @@ class Metro::Importer
     import_trips!
     @logger.info("Step 5/5: Importing stop times (#{source.stop_times.size})")
     import_stop_times!
+    update_route_stop_cache!
     true
+  end
+
+  def update_route_stop_cache!
+    RouteStop.update_cache
   end
 
   def import_services!

--- a/app/models/route_stop.rb
+++ b/app/models/route_stop.rb
@@ -1,0 +1,27 @@
+class RouteStop < ActiveRecord::Base
+  belongs_to :route
+  belongs_to :stop
+
+  validates :route, presence: true
+  validates :stop, presence: true
+  validates_uniqueness_of :route, scope: :stop_id
+
+  def self.update_cache
+    transaction do
+      connection.execute 'TRUNCATE TABLE route_stops'
+      connection.execute <<-SQL
+        INSERT INTO route_stops (route_id, stop_id)
+          SELECT DISTINCT
+            routes.id as route_id, stops.id as stop_id
+          FROM
+            routes
+          INNER JOIN
+            trips ON trips.route_id = routes.id
+          INNER JOIN
+            stop_times ON stop_times.trip_id = trips.id
+          INNER JOIN
+            stops ON stops.id = stop_times.stop_id
+      SQL
+    end
+  end
+end

--- a/app/models/stop.rb
+++ b/app/models/stop.rb
@@ -2,7 +2,15 @@ class Stop < ActiveRecord::Base
   acts_as_mappable(lat_column_name: :latitude, lng_column_name: :longitude)
   has_many :stop_times
   has_many :trips, through: :stop_times
-  has_many :routes, -> { uniq }, through: :trips
+
+  # To get a stops routes, we have to query through a lot of tables:
+  #
+  # stops -> stop_times -> trips -> routes and it's pretty slow.
+  #
+  # On import we denormalize the data into route_stops for better performance.
+  has_many :route_stops, dependent: :destroy
+  has_many :routes, through: :route_stops
+
   belongs_to :agency
 
   include PgSearch

--- a/db/migrate/20150503132110_create_route_stops.rb
+++ b/db/migrate/20150503132110_create_route_stops.rb
@@ -1,0 +1,10 @@
+class CreateRouteStops < ActiveRecord::Migration
+  def change
+    create_table :route_stops do |t|
+      t.integer :route_id, null: false
+      t.integer :stop_id, null: false
+    end
+
+    add_index :route_stops, [:stop_id, :route_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150501165537) do
+ActiveRecord::Schema.define(version: 20150503132110) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,6 +28,13 @@ ActiveRecord::Schema.define(version: 20150501165537) do
   end
 
   add_index "agencies", ["remote_id"], name: "index_agencies_on_remote_id", using: :btree
+
+  create_table "route_stops", force: :cascade do |t|
+    t.integer "route_id", null: false
+    t.integer "stop_id",  null: false
+  end
+
+  add_index "route_stops", ["stop_id", "route_id"], name: "index_route_stops_on_stop_id_and_route_id", unique: true, using: :btree
 
   create_table "routes", force: :cascade do |t|
     t.string   "remote_id"

--- a/lib/tasks/metro.rake
+++ b/lib/tasks/metro.rake
@@ -14,6 +14,12 @@ namespace :metro do
     end
   end
 
+  desc "Update route_stop cache"
+  task update_route_stop_cache: :environment do
+    ActiveRecord::Base.logger.level = 2
+    RouteStop.update_cache
+  end
+
   desc "Titleize existing metro data"
   task titleize: :environment do
     Stop.find_each do |s|

--- a/spec/factories/route_stops.rb
+++ b/spec/factories/route_stops.rb
@@ -1,0 +1,4 @@
+FactoryGirl.define do
+  factory :route_stop do
+  end
+end

--- a/spec/models/stop_spec.rb
+++ b/spec/models/stop_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Stop do
 
     let!(:trip) { create(:trip, route: route)}
     let!(:stop_time) { create(:stop_time, stop: stop, trip: trip) }
+    let!(:route_stop) { create(:route_stop, route: route, stop: stop) }
 
     it "associates routes to each stop" do
       expect(stop.routes).to eq([route])


### PR DESCRIPTION
Instead of traversing all of the relationships to find a stop's routes. We pre-calculate this information into a separate table during import.

This improve the performance of /api/stops?query=main on my machine from 450ms to 90ms. I think we should see a similar performance impact on heroku.

Once deployed with migrations, you can run `rake metro:update_route_stop_cache` to update the cache.

/cc @rockwood 