### PR TITLE
Allow per_page and page to be set via URL

### DIFF
--- a/app/models/stop_searcher.rb
+++ b/app/models/stop_searcher.rb
@@ -2,11 +2,12 @@ class StopSearcher
   include ActiveModel::SerializerSupport
   DEFAULT_PER_PAGE = 20
 
-  attr_reader :per_page
+  attr_reader :per_page, :page
 
   def initialize(params)
     @params = params
     @per_page = params.fetch(:per_page) { DEFAULT_PER_PAGE }.to_i
+    @page = params.fetch(:page) { 1 }.to_i
   end
 
   def results
@@ -19,10 +20,6 @@ class StopSearcher
 
   def total_pages
     total_results / per_page
-  end
-
-  def page
-    @params[:page] || 1
   end
 
   def offset

--- a/app/models/stop_searcher.rb
+++ b/app/models/stop_searcher.rb
@@ -2,16 +2,15 @@ class StopSearcher
   include ActiveModel::SerializerSupport
   DEFAULT_PER_PAGE = 20
 
+  attr_reader :per_page
+
   def initialize(params)
     @params = params
+    @per_page = params.fetch(:per_page) { DEFAULT_PER_PAGE }.to_i
   end
 
   def results
     @results ||= paginated_results
-  end
-
-  def per_page
-    @params[:per_page] || DEFAULT_PER_PAGE
   end
 
   def total_results

--- a/spec/models/stop_searcher_spec.rb
+++ b/spec/models/stop_searcher_spec.rb
@@ -99,5 +99,18 @@ describe StopSearcher do
         expect(stop_searcher.total_pages).to eq(2)
       end
     end
+
+    context "when page is a string" do
+      let(:params) { { per_page: 5, page: '2' } }
+
+      it "has a page" do
+        expect(stop_searcher.page).to eq(2)
+      end
+
+      it "paginates the results" do
+        expect(stop_searcher.results.size).to eq(5)
+        expect(stop_searcher.results).to include(last_stop)
+      end
+    end
   end
 end

--- a/spec/models/stop_searcher_spec.rb
+++ b/spec/models/stop_searcher_spec.rb
@@ -87,5 +87,17 @@ describe StopSearcher do
     it "has total_results" do
       expect(stop_searcher.total_results).to eq(10)
     end
+
+    context 'when per_page is a string' do
+      let(:params) { { per_page: '5' } }
+
+      it "sets per_page" do
+        expect(stop_searcher.per_page).to eq(5)
+      end
+
+      it "has total_pages" do
+        expect(stop_searcher.total_pages).to eq(2)
+      end
+    end
   end
 end


### PR DESCRIPTION
/api/stops?query=main&per_page=100 was generating an error because per_page was not being converted to an integer.