### PR TITLE
Delayed departures

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 PORT=3000
+REDISTOGO_URL=redis://localhost:6379/

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,8 @@ group :development, :test do
   gem 'byebug'
   gem 'dotenv-rails'
   gem 'factory_girl_rails'
+  gem 'pry'
+  gem 'pry-byebug'
   gem 'rspec-rails'
   gem 'spring'
   gem 'spring-commands-rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,7 @@ GEM
     builder (3.2.2)
     byebug (4.0.5)
       columnize (= 0.9.0)
+    coderay (1.1.0)
     columnize (0.9.0)
     database_cleaner (1.4.1)
     debug_inspector (0.0.2)
@@ -78,6 +79,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
+    method_source (0.8.2)
     mime-types (2.5)
     mini_portile (0.6.2)
     minitest (5.6.1)
@@ -90,6 +92,13 @@ GEM
       activerecord (>= 3.1)
       activesupport (>= 3.1)
       arel
+    pry (0.10.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-byebug (3.1.0)
+      byebug (~> 4.0)
+      pry (~> 0.10)
     puma (2.11.2)
       rack (>= 1.1, < 2.0)
     rack (1.6.1)
@@ -153,6 +162,7 @@ GEM
       json (~> 1.8)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
+    slop (3.6.0)
     spring (1.3.6)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
@@ -188,6 +198,8 @@ DEPENDENCIES
   gtfs
   pg
   pg_search
+  pry
+  pry-byebug
   puma
   rack-cors
   rails (~> 4.2.0)

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+web: bundle exec puma -C config/puma.rb
+redis: redis-server

--- a/app/models/departure.rb
+++ b/app/models/departure.rb
@@ -1,3 +1,5 @@
+require 'duration'
+
 class Departure
   include ActiveModel::SerializerSupport
   attr_reader :stop_time
@@ -9,6 +11,10 @@ class Departure
   end
 
   delegate :route, :trip, to: :stop_time
+
+  def duration_from(t)
+    ::Duration.new(time - t)
+  end
 
   def realtime?
     @stop_time_update.present?

--- a/app/models/departure_fetcher.rb
+++ b/app/models/departure_fetcher.rb
@@ -6,7 +6,7 @@ class DepartureFetcher
   def initialize(params)
     @time = params[:time] ? Time.zone.parse(params[:time]) : Time.current
     @stop_id = params[:stop_id]
-    @time_limit = params.fetch(:time_limit, 10)
+    @time_limit = params.fetch(:time_limit, 10).to_i
 
     @active_duration = Duration.new((-1 * @time_limit.minutes))
   end

--- a/app/models/departure_fetcher.rb
+++ b/app/models/departure_fetcher.rb
@@ -1,16 +1,21 @@
+require 'duration'
+
 class DepartureFetcher
   include ActiveModel::SerializerSupport
 
   def initialize(params)
     @time = params[:time] ? Time.zone.parse(params[:time]) : Time.current
     @stop_id = params[:stop_id]
+    @time_limit = params.fetch(:time_limit, 10)
+
+    @active_duration = Duration.new((-1 * @time_limit.minutes))
   end
 
   def departures
     @departures ||= stop_times.map { |stop_time|
       stop_time_update = realtime_updates.for_stop_time(stop_time)
       Departure.new(date: @time.to_date, stop_time: stop_time, stop_time_update: stop_time_update)
-    }.sort_by(&:time)
+    }.sort_by(&:time).select { |d| active?(d) }
   end
 
   def stop_times
@@ -26,9 +31,13 @@ class DepartureFetcher
 
   private
 
+  def active?(departure)
+    departure.duration_from(@time) >= @active_duration
+  end
+
   def time_query
     {
-      start_time: @time - 10.minutes,
+      start_time: @time - 1.hour,
       end_time: @time + 1.hour
     }
   end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -4,6 +4,8 @@ class Service < ActiveRecord::Base
   has_many :stop_times, through: :trips
 
   def self.for_time(time)
+    # This looks weird, but the days are boolean columns and
+    # 'select * from foo where bar' works in postgres for boolean columns
     where(time.strftime('%A').downcase)
   end
 end

--- a/lib/duration.rb
+++ b/lib/duration.rb
@@ -1,0 +1,56 @@
+class Duration
+  include Comparable
+
+  attr_reader :seconds
+
+  def initialize(args = 0)
+    @seconds = args.to_i
+  end
+
+  def minutes
+    @seconds / 60
+  end
+
+  def hours
+    minutes / 60
+  end
+
+  # Compare this duration to another
+  def <=>(other)
+    return false unless other.is_a?(Duration)
+    @seconds <=> other.seconds
+  end
+
+  def +(other)
+    Duration.new(@seconds + other.to_i)
+  end
+
+  def -(other)
+    Duration.new(@seconds - other.to_i)
+  end
+
+  def *(other)
+    Duration.new(@seconds * other.to_i)
+  end
+
+  def /(other)
+    Duration.new(@seconds / other.to_i)
+  end
+
+  # @return true if total is 0
+  def blank?
+    @seconds == 0
+  end
+
+  # @return true if total different than 0
+  def present?
+    !blank?
+  end
+
+  def negative?
+    @negative
+  end
+
+  alias_method :to_i, :seconds
+end
+

--- a/spec/models/departure_spec.rb
+++ b/spec/models/departure_spec.rb
@@ -1,75 +1,81 @@
 require 'rails_helper'
 
 RSpec.describe Departure do
+  let!(:now) { Time.zone.now }
   let(:time) { Time.zone.parse("2015-04-23 7:30") }
   let(:stop_time) { create(:stop_time, departure_time: time) }
+
   subject(:departure) { Departure.new(date: time.to_date, stop_time: stop_time, stop_time_update: stop_time_update) }
 
-  describe "time" do
-    context "with no stop_time_update" do
-      let(:stop_time_update) { nil }
+  context "with no stop_time_update" do
+    let(:stop_time_update) { nil }
 
-      it "is stop_time.departure_time" do
-        expect(departure.time).to eq(stop_time.departure_time)
+    it "has the time of the scheduled departure_time" do
+      expect(departure.time).to eq(stop_time.departure_time)
+    end
+
+    it "applies the date to the stop_time (because the database resets it to 2000-01-01)" do
+      stop_time.reload
+      expect(departure.time).to eq(time)
+    end
+
+    it "is not realtime" do
+      expect(departure).not_to be_realtime
+    end
+
+    it "has no delay" do
+      expect(departure.delay).to eq(0)
+    end
+
+    it "calculates the duration from the scheduled departure time" do
+      expect(departure.duration_from(time)).to eq(Duration.new(0.minutes))
+    end
+
+    context "with a scheduled time in the past" do
+      let(:time) { now - 5.minutes }
+
+      it "can calculate the duration from the scheduled departure time in the past" do
+        expect(departure.duration_from(now)).to eq(Duration.new(-5.minutes))
       end
+    end
 
-      it "applies the date to the stop_time (because the database resets it to 2000-01-01)" do
+    context "When time could span across a dateline" do
+      let(:time) { Time.zone.parse("2015-04-23 23:00") }
+
+      it "maintains the correct date" do
         stop_time.reload
         expect(departure.time).to eq(time)
       end
-
-      context "When time could span across a dateline" do
-        let(:time) { Time.zone.parse("2015-04-23 23:00") }
-
-        it "maintains the correct date" do
-          stop_time.reload
-          expect(departure.time).to eq(time)
-        end
-      end
-    end
-
-    context "with a stop_time_update" do
-      let(:stop_time_update) { OpenStruct.new(departure_time: Time.new) }
-
-      it "is stop_time_update.departure_time" do
-        expect(departure.time).to eq(stop_time_update.departure_time)
-      end
     end
   end
 
-  describe "realtime?" do
-    context "with no stop_time_update" do
-      let(:stop_time_update) { nil }
+  context "with a stop_time_update" do
+    let(:time) { now + 5.minutes }
+    let(:stop_time_update) { OpenStruct.new(departure_time: time, delay: 10) }
 
-      it "is false" do
-        expect(departure.realtime?).to eq(false)
-      end
+    it "has the time of the realtime departure_time" do
+      expect(departure.time).to eq(stop_time_update.departure_time)
     end
 
-    context "with a stop_time_update" do
-      let(:stop_time_update) { OpenStruct.new(departure_time: Time.new) }
-
-      it "is true" do
-        expect(departure.realtime?).to eq(true)
-      end
-    end
-  end
-
-  describe "delay" do
-    context "with no stop_time_update" do
-      let(:stop_time_update) { nil }
-
-      it "is false" do
-        expect(departure.delay).to eq(0)
-      end
+    it "is realtime" do
+      expect(departure).to be_realtime
     end
 
-    context "with a delayed stop_time_update" do
-      let(:stop_time_update) { OpenStruct.new(departure_time: Time.new, delay: 10) }
+    it "has a delay" do
+      expect(departure.delay).to eq(10)
+    end
 
-      it "is true" do
-        expect(departure.delay).to eq(10)
+    it "can calculate the duration from the realtime departure time" do
+      expect(departure.duration_from(now)).to eq(Duration.new(5.minutes))
+    end
+
+    context "with a departure time in the past" do
+      let(:time) { now - 5.minutes }
+
+      it "can calculate the duration from the scheduled departure time in the past" do
+        expect(departure.duration_from(now)).to eq(Duration.new(-5.minutes))
       end
     end
   end
 end
+

--- a/spec/requests/departures_request_spec.rb
+++ b/spec/requests/departures_request_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe "departures api" do
   let(:json) { JSON.parse(response.body) }
 
   describe "api/departures" do
-    let(:now) { Time.zone.parse("2015-04-23 7:30am") }
-    let!(:trip) { create(:trip, remote_id: 940135, service: create(:service, thursday: true)) }
+    let(:now) { Time.zone.parse("2015-02-16 17:55:00 -0500") }
+    let!(:trip) { create(:trip, remote_id: 940135, service: create(:service, monday: true)) }
     let!(:stop) { create(:stop, remote_id: "HAMBELi") }
     let!(:stop_time) { create(:stop_time, stop: stop, trip: trip, departure_time: now + 10.minutes) }
 


### PR DESCRIPTION
Fixes #7 

Include all scheduled stops +/- 1 hour from the time. Show stop times without real-time updates until they are 10 minutes past. Show those that have real-time updates until the real-time time is more than 10 minutes past.