### PR TITLE
Agency independent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Bus Detective
 
-Ruby: 2.2.0 - Rails: 4.2.0
-PostgreSQL
-Redis
+* Ruby: 2.2.0 - Rails: 4.2.0
+* PostgreSQL
+* Redis
 
 ### Setup
 

--- a/app/apis/metro/connection.rb
+++ b/app/apis/metro/connection.rb
@@ -1,11 +1,16 @@
+require 'uri'
+
 module Metro
   class Connection
-    def self.host
-      'developer.go-metro.com'
-    end
 
-    def self.get(endpoint)
-      Net::HTTP.get(host, endpoint)
+    def self.get(url)
+      uri = if url.is_a? URI
+              url
+            else
+              URI(url)
+            end
+
+      Net::HTTP.get(uri)
     end
   end
 end

--- a/app/apis/metro/realtime_updates.rb
+++ b/app/apis/metro/realtime_updates.rb
@@ -3,10 +3,8 @@ require 'time'
 
 module Metro
   class RealtimeUpdates
-    ENDPOINT = "/TMGTFSRealTimeWebService/TripUpdate/"
-
-    def self.fetch
-      new(Connection.get(ENDPOINT))
+    def self.fetch(agency)
+      new(Connection.get(agency.realtime_endpoint))
     end
 
     def initialize(buffer)

--- a/app/controllers/api/departures_controller.rb
+++ b/app/controllers/api/departures_controller.rb
@@ -1,10 +1,33 @@
 class Api::DeparturesController < ApiController
   def index
-    fetcher = DepartureFetcher.new(params)
+    fetcher = departure_fetcher.new(agency, stop, time)
     if fetcher.valid?
-      render json: fetcher
+      render json: fetcher, serializer: DepartureFetcherSerializer
     else
       render json: { errors: "Invalid parameters" }, status: :bad_request
     end
+  end
+
+  private
+
+  def departure_fetcher
+    @departure_fetcher ||= if agency && agency.realtime?
+                             RealtimeDepartureFetcher
+                           else
+                             DepartureFetcher
+                           end
+  end
+
+  def stop
+    @stop ||= Stop.find_legacy(params[:stop_id])
+  end
+
+  def agency
+    return nil unless stop
+    @agency ||= stop.agency
+  end
+
+  def time
+    params[:time] ? Time.zone.parse(params[:time]) : Time.current
   end
 end

--- a/app/controllers/api/stops_controller.rb
+++ b/app/controllers/api/stops_controller.rb
@@ -1,6 +1,6 @@
 class Api::StopsController < ApiController
   def index
-    searcher =  StopSearcher.new(params)
+    searcher = StopSearcher.new(params)
     if searcher.valid?
       render json: searcher
     else

--- a/app/models/agency.rb
+++ b/app/models/agency.rb
@@ -4,4 +4,8 @@ class Agency < ActiveRecord::Base
   has_many :stop_times
   has_many :routes
   has_many :services
+
+  def realtime?
+    realtime_endpoint.present?
+  end
 end

--- a/app/models/departure_fetcher.rb
+++ b/app/models/departure_fetcher.rb
@@ -1,52 +1,38 @@
-require 'duration'
-
 class DepartureFetcher
   include ActiveModel::SerializerSupport
 
-  def initialize(params)
-    @time = params[:time] ? Time.zone.parse(params[:time]) : Time.current
-    @stop_id = params[:stop_id]
-    @time_limit = params.fetch(:time_limit, 10).to_i
-
-    @active_duration = Duration.new((-1 * @time_limit.minutes))
+  attr_reader :agency, :stop, :time
+  def initialize(agency, stop, time, params = {})
+    @agency = agency
+    @time = time.in_time_zone
+    @stop = stop
   end
 
   def departures
     @departures ||= stop_times.map { |stop_time|
-      stop_time_update = realtime_updates.for_stop_time(stop_time)
-      Departure.new(date: @time.to_date, stop_time: stop_time, stop_time_update: stop_time_update)
-    }.sort_by(&:time).select { |d| active?(d) }
+      Departure.new(date: @time.to_date, stop_time: stop_time, stop_time_update: nil)
+    }.sort_by(&:time)
   end
 
   def stop_times
-    @stop_times ||= StopTime
-      .where(stop: stop, trips: { service_id: Service.for_time(@time) })
+    @stop_times ||= agency.stop_times
+      .where(stop: stop, trips: { service_id: agency.services.for_time(@time) })
       .where("departure_time > :start_time AND departure_time < :end_time", time_query)
       .includes(:route, :trip, :stop)
+      .to_a
   end
 
   def valid?
-    @stop_id.present?
+    @agency.present? && @stop.present?
   end
 
-  private
-
-  def active?(departure)
-    departure.duration_from(@time) >= @active_duration
-  end
+  protected
 
   def time_query
     {
-      start_time: @time - 1.hour,
+      start_time: @time - 10.minutes,
       end_time: @time + 1.hour
     }
   end
-
-  def stop
-    @stop ||= Stop.find_legacy(@stop_id)
-  end
-
-  def realtime_updates
-    @realtime_updates ||= Metro::RealtimeUpdates.fetch
-  end
 end
+

--- a/app/models/realtime_departure_fetcher.rb
+++ b/app/models/realtime_departure_fetcher.rb
@@ -1,0 +1,36 @@
+require 'duration'
+
+class RealtimeDepartureFetcher < DepartureFetcher
+  include ActiveModel::SerializerSupport
+
+  def initialize(agency, stop, time, params = {})
+    super(agency, stop, time, params)
+
+    time_limit = params.fetch(:time_limit, 10).to_i
+    @active_duration = Duration.new((-1 * time_limit.minutes))
+  end
+
+  def departures
+    @departures ||= stop_times.map { |stop_time|
+      stop_time_update = realtime_updates.for_stop_time(stop_time)
+      Departure.new(date: @time.to_date, stop_time: stop_time, stop_time_update: stop_time_update)
+    }.sort_by(&:time).select { |d| active?(d) }
+  end
+
+  private
+
+  def time_query
+    {
+      start_time: @time - 1.hour,
+      end_time: @time + 1.hour
+    }
+  end
+
+  def active?(departure)
+    departure.duration_from(@time) >= @active_duration
+  end
+
+  def realtime_updates
+    @realtime_updates ||= Metro::RealtimeUpdates.fetch(agency)
+  end
+end

--- a/app/models/stop.rb
+++ b/app/models/stop.rb
@@ -32,6 +32,7 @@ class Stop < ActiveRecord::Base
   def self.find_legacy(id)
     # This is to support the case where a user has a favorite saved from
     # before the switch to postres generated ids
-    Stop.where(id: id).first || Stop.find_by!(remote_id: id)
+    t = Stop.arel_table
+    Stop.where(t[:id].eq(id).or(t[:remote_id].eq(id))).includes(:agency).first
   end
 end

--- a/app/serializers/agency_serializer.rb
+++ b/app/serializers/agency_serializer.rb
@@ -1,0 +1,5 @@
+class AgencySerializer < ApplicationSerializer
+  attributes :id, :remote_id, :name, :url, :fare_url, :phone, :timezone
+end
+
+

--- a/app/serializers/route_serializer.rb
+++ b/app/serializers/route_serializer.rb
@@ -1,4 +1,5 @@
 class RouteSerializer < ApplicationSerializer
   attributes :id, :short_name, :long_name, :color, :text_color
+  has_one :agency
 end
 

--- a/app/serializers/stop_serializer.rb
+++ b/app/serializers/stop_serializer.rb
@@ -1,10 +1,7 @@
 class StopSerializer < ApplicationSerializer
   attributes :id, :name, :direction, :latitude, :longitude
 
-  def stop_id
-    object.remote_id
-  end
-
   has_many :routes
+  has_one :agency
 end
 

--- a/app/serializers/trip_serializer.rb
+++ b/app/serializers/trip_serializer.rb
@@ -1,4 +1,5 @@
 class TripSerializer < ApplicationSerializer
   attributes :id, :headsign
+  has_one :agency
 end
 

--- a/db/migrate/20150512134125_use_foreign_keys.rb
+++ b/db/migrate/20150512134125_use_foreign_keys.rb
@@ -1,0 +1,15 @@
+class UseForeignKeys < ActiveRecord::Migration
+  def change
+    add_foreign_key :route_stops, :routes
+    add_foreign_key :route_stops, :stops
+    add_foreign_key :routes, :agencies
+    add_foreign_key :services, :agencies
+    add_foreign_key :stop_times, :agencies
+    add_foreign_key :stop_times, :stops
+    add_foreign_key :stop_times, :trips
+    add_foreign_key :stops, :agencies
+    add_foreign_key :trips, :services
+    add_foreign_key :trips, :agencies
+    add_foreign_key :trips, :routes
+  end
+end

--- a/db/migrate/20150512135655_add_realtime_endpoint_to_agencies.rb
+++ b/db/migrate/20150512135655_add_realtime_endpoint_to_agencies.rb
@@ -1,0 +1,5 @@
+class AddRealtimeEndpointToAgencies < ActiveRecord::Migration
+  def change
+    add_column :agencies, :realtime_endpoint, :string
+  end
+end

--- a/db/migrate/20150512192738_set_realtime_endpoint.rb
+++ b/db/migrate/20150512192738_set_realtime_endpoint.rb
@@ -1,0 +1,5 @@
+class SetRealtimeEndpoint < ActiveRecord::Migration
+  def up
+    Agency.where(gtfs_endpoint: "http://www.go-metro.com/uploads/GTFS/google_transit_info.zip").update_all(realtime_endpoint: "http://developer.go-metro.com/TMGTFSRealTimeWebService/TripUpdate/")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150503132110) do
+ActiveRecord::Schema.define(version: 20150512134125) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -132,4 +132,15 @@ ActiveRecord::Schema.define(version: 20150503132110) do
   add_index "trips", ["remote_id", "agency_id"], name: "index_trips_on_remote_id_and_agency_id", using: :btree
   add_index "trips", ["route_id"], name: "index_trips_on_route_id", using: :btree
 
+  add_foreign_key "route_stops", "routes"
+  add_foreign_key "route_stops", "stops"
+  add_foreign_key "routes", "agencies"
+  add_foreign_key "services", "agencies"
+  add_foreign_key "stop_times", "agencies"
+  add_foreign_key "stop_times", "stops"
+  add_foreign_key "stop_times", "trips"
+  add_foreign_key "stops", "agencies"
+  add_foreign_key "trips", "agencies"
+  add_foreign_key "trips", "routes"
+  add_foreign_key "trips", "services"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150512134125) do
+ActiveRecord::Schema.define(version: 20150512135655) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,7 @@ ActiveRecord::Schema.define(version: 20150512134125) do
     t.string "language"
     t.string "phone"
     t.string "gtfs_endpoint"
+    t.string "realtime_endpoint"
   end
 
   add_index "agencies", ["remote_id"], name: "index_agencies_on_remote_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150512135655) do
+ActiveRecord::Schema.define(version: 20150512192738) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/apis/metro/realtime_updates_spec.rb
+++ b/spec/apis/metro/realtime_updates_spec.rb
@@ -2,18 +2,20 @@ require 'rails_helper'
 
 RSpec.describe Metro::RealtimeUpdates do
   let(:fixture) { File.read('spec/fixtures/realtime_updates.buf') }
-  subject(:realtime_updates) { Metro::RealtimeUpdates.new(fixture) }
+  subject { Metro::RealtimeUpdates.new(fixture) }
 
   describe "#fetch" do
+    let(:agency) { create(:agency, :with_rt_endpoint) }
+
     it "calls Connection.get with the endpoint" do
-      allow(Metro::Connection).to receive(:get).and_return(fixture)
-      Metro::RealtimeUpdates.fetch
-      expect(Metro::Connection).to have_received(:get).with(Metro::RealtimeUpdates::ENDPOINT)
+      allow(Metro::Connection).to receive(:get).with(agency.realtime_endpoint).and_return(fixture)
+      Metro::RealtimeUpdates.fetch(agency)
+      expect(Metro::Connection).to have_received(:get).with(agency.realtime_endpoint)
     end
   end
 
   describe "#for_trip" do
-    let(:trip_update) { realtime_updates.for_trip(trip) }
+    let(:trip_update) { subject.for_trip(trip) }
 
     context "with a matching trip.remote_id" do
       let(:trip) { build(:trip, remote_id: 940135) }
@@ -26,13 +28,13 @@ RSpec.describe Metro::RealtimeUpdates do
     context "with a non-matching trip.remote_id" do
       let(:trip) { build(:trip, remote_id: 999999) }
       it "returns nil" do
-        expect(realtime_updates.for_trip(trip)).to be_nil
+        expect(subject.for_trip(trip)).to be_nil
       end
     end
   end
 
   describe "#for_stop_time" do
-    let(:stop_time_update) { realtime_updates.for_stop_time(stop_time) }
+    let(:stop_time_update) { subject.for_stop_time(stop_time) }
 
     context "with a matching stop_time.trip.remote_id and stop_time.stop.remote.id" do
       let!(:trip) { build(:trip, remote_id: 940135) }
@@ -48,7 +50,7 @@ RSpec.describe Metro::RealtimeUpdates do
     context "with a non-matching stop_time" do
       let(:stop_time) { build(:stop_time) }
       it "returns nil" do
-        expect(realtime_updates.for_stop_time(stop_time)).to be_nil
+        expect(subject.for_stop_time(stop_time)).to be_nil
       end
     end
   end

--- a/spec/factories/agencies.rb
+++ b/spec/factories/agencies.rb
@@ -1,5 +1,0 @@
-FactoryGirl.define do
-  factory :agency do
-    name "Test agency"
-  end
-end

--- a/spec/factories/agencies_factory.rb
+++ b/spec/factories/agencies_factory.rb
@@ -1,0 +1,13 @@
+FactoryGirl.define do
+  factory :agency do
+    name 'Test agency'
+    remote_id 'TEST'
+    url 'http://example.com'
+    language 'en'
+    timezone 'America/New_York'
+
+    trait :with_rt_endpoint do
+      realtime_endpoint 'http://example.com/gtfs'
+    end
+  end
+end

--- a/spec/factories/route_factory.rb
+++ b/spec/factories/route_factory.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :route do
     sequence(:remote_id)
+    agency
   end
 end

--- a/spec/factories/route_stops.rb
+++ b/spec/factories/route_stops.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :route_stop do
-  end
-end

--- a/spec/factories/route_stops_factory.rb
+++ b/spec/factories/route_stops_factory.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :route_stop do
+    after(:build) do |rs|
+      agency = build(:agency)
+      rs.route = build(:route, agency: agency) unless rs.route
+      rs.stop = build(:stop, agency: agency) unless rs.stop
+    end
+  end
+end

--- a/spec/factories/services_factory.rb
+++ b/spec/factories/services_factory.rb
@@ -1,4 +1,5 @@
 FactoryGirl.define do
   factory :service do
+    agency
   end
 end

--- a/spec/factories/stop_factory.rb
+++ b/spec/factories/stop_factory.rb
@@ -2,5 +2,6 @@ FactoryGirl.define do
   factory :stop do
     name "Test stop"
     sequence(:remote_id)
+    agency
   end
 end

--- a/spec/factories/stop_time_factory.rb
+++ b/spec/factories/stop_time_factory.rb
@@ -1,6 +1,10 @@
 FactoryGirl.define do
   factory :stop_time do
-    stop
-    trip
+    agency
+
+    after(:build) do |st|
+      st.stop = build(:stop, agency: st.agency) unless st.stop
+      st.trip = build(:trip, agency: st.agency) unless st.trip
+    end
   end
 end

--- a/spec/factories/trip_factory.rb
+++ b/spec/factories/trip_factory.rb
@@ -2,6 +2,10 @@ FactoryGirl.define do
   factory :trip do
     sequence(:remote_id)
     sequence(:headsign) { |n| "Bus #{n}" }
-    service
+    agency
+
+    after(:build) do |t|
+      t.service = build(:service, agency: t.agency) unless t.service
+    end
   end
 end

--- a/spec/models/agency_spec.rb
+++ b/spec/models/agency_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe Agency do
+
+  context 'with a realtime_endpoint' do
+    subject { create(:agency, :with_rt_endpoint) }
+    it { is_expected.to be_realtime }
+  end
+
+  context 'without a realtime_endpoint' do
+    subject { create(:agency, realtime_endpoint: nil) }
+    it { is_expected.not_to be_realtime }
+  end
+end

--- a/spec/models/departure_fetcher_spec.rb
+++ b/spec/models/departure_fetcher_spec.rb
@@ -3,125 +3,65 @@ require 'rails_helper'
 RSpec.describe DepartureFetcher do
   let(:now) { Time.zone.parse("2015-04-23 7:30am") }
   let(:stop) { create(:stop) }
-  let(:trip) { create(:trip, service: create(:service, thursday: true)) }
-  subject(:stop_time_fetcher) { DepartureFetcher.new(params) }
+  let(:agency) { stop.agency }
+  let(:trip) { create(:trip, agency: agency, service: create(:service, agency: agency, thursday: true)) }
+  subject { DepartureFetcher.new(agency, stop, now) }
 
   describe "#stop_times" do
     let!(:applicable_stop_time) {
-      create(:stop_time, stop: stop, trip: trip, departure_time: now + 10.minutes)
+      create(:stop_time, agency: agency, stop: stop, trip: trip, departure_time: now + 10.minutes)
     }
     let!(:out_of_time_range_stop_time) {
-      create(:stop_time, stop: stop, trip: trip, departure_time: now - 2.hours)
+      create(:stop_time, agency: agency, stop: stop, trip: trip, departure_time: now - 2.hours)
     }
     let!(:different_service_stop_time) {
-      create(:stop_time, stop: stop, trip: create(:trip), departure_time: now)
+      create(:stop_time, agency: agency, stop: stop, trip: create(:trip, agency: agency), departure_time: now)
     }
-    let(:params) { { stop_id: stop.id, time: now.to_s } }
 
     it "searches stop_times within a time range and on the service" do
-      expect(stop_time_fetcher.stop_times).to eq([applicable_stop_time])
+      expect(subject.stop_times).to eq([applicable_stop_time])
     end
   end
 
-  describe "#departures" do
-    let!(:stop_time) { create(:stop_time, stop: stop, trip: trip, departure_time: now + 10.minutes) }
-    let(:params) { { stop_id: stop.id, time: now.to_s } }
-    let(:fake_realtime_updates) { double("RealtimeUpdates", for_stop_time: fake_stop_time_update) }
+  describe "departures without realtime updates" do
+    let(:departure_time) { now + 10.minutes }
+    let!(:stop_time) { create(:stop_time, agency: agency, stop: stop, trip: trip, departure_time: departure_time) }
 
-    before do
-      allow(Metro::RealtimeUpdates).to receive(:fetch).and_return(fake_realtime_updates)
+    it "creates one for each stop_time" do
+      expect(subject.departures.size).to eq(1)
     end
 
-    context "when an associated realtime update exists for the stop time" do
-      let(:fake_stop_time_update) { OpenStruct.new(departure_time: now + 15.minutes) }
-
-      it "creates one for each stop_time" do
-        expect(stop_time_fetcher.departures.size).to eq(1)
-      end
-
-      it "is realtime" do
-        expect(stop_time_fetcher.departures.first).to be_realtime
-      end
-
-      it "applies the departure time from the realtime update" do
-        expect(stop_time_fetcher.departures.first.time).to eq(fake_stop_time_update.departure_time)
-      end
+    it "is not realtime" do
+      expect(subject.departures.first).to_not be_realtime
     end
 
-    context "when an associated realtime update does not exist for the stop time" do
-      let(:fake_stop_time_update) { nil }
-
-      it "creates one for each stop_time" do
-        expect(stop_time_fetcher.departures.size).to eq(1)
-      end
-
-      it "is not realtime" do
-        expect(stop_time_fetcher.departures.first).to_not be_realtime
-      end
-
-      it "applies the departure time the scheduled stop_time" do
-        expect(stop_time_fetcher.departures.first.time).to eq(stop_time.departure_time)
-      end
+    it "applies the departure time the scheduled stop_time" do
+      expect(subject.departures.first.time).to eq(stop_time.departure_time)
     end
 
     context "when a departure is less than 10 minutes past" do
-      let!(:stop_time) { create(:stop_time, stop: stop, trip: trip, departure_time: now - 9.minutes) }
+      let(:departure_time) { now - 9.minutes }
 
-      context "and realtime updates are in the past for the stop time" do
-        let(:fake_stop_time_update) { OpenStruct.new(departure_time: now - 9.minutes) }
-
-        it "it shows already past departures for a short while" do
-          expect(stop_time_fetcher.departures.size).to eq(1)
-        end
-      end
-
-      context "and realtime updates do not exist for the stop time" do
-        let(:fake_stop_time_update) { nil }
-
-        it "it shows already past departures for a short while" do
-          expect(stop_time_fetcher.departures.size).to eq(1)
-        end
+      it "it shows already past departures for a short while" do
+        expect(subject.departures.size).to eq(1)
       end
     end
 
     context "when a departure is up to an hour in the past" do
-      let!(:stop_time) { create(:stop_time, stop: stop, trip: trip, departure_time: now - 55.minutes) }
+      let(:departure_time) { now - 55.minutes }
 
-      context "and realtime updates are available showing upcoming departure for the stop time" do
-        let(:fake_stop_time_update) { OpenStruct.new(departure_time: now + 5.minutes) }
-
-        it "shows late departures up to an hour past due" do
-          expect(stop_time_fetcher.departures.size).to eq(1)
-        end
-      end
-
-      context "and realtime updates do not exist for the stop time" do
-        let(:fake_stop_time_update) { nil }
-
-        it "it won't show that stop time" do
-          expect(stop_time_fetcher.departures.size).to be_zero
-        end
+      it "it won't show that stop time" do
+        expect(subject.departures.size).to be_zero
       end
     end
 
     context "when a departure is more than an hour in the past" do
-      let!(:stop_time) { create(:stop_time, stop: stop, trip: trip, departure_time: now - 65.minutes) }
+      let(:departure_time) { now - 65.minutes }
 
-      context "and realtime updates are available showing upcoming departure for the stop time" do
-        let(:fake_stop_time_update) { OpenStruct.new(departure_time: now + 5.minutes) }
-
-        it "it won't show that stop time" do
-          expect(stop_time_fetcher.departures.size).to be_zero
-        end
-      end
-
-      context "and realtime updates do not exist for the stop time" do
-        let(:fake_stop_time_update) { nil }
-
-        it "it won't show that stop time" do
-          expect(stop_time_fetcher.departures.size).to be_zero
-        end
+      it "it won't show that stop time" do
+        expect(subject.departures.size).to be_zero
       end
     end
   end
 end
+

--- a/spec/models/realtime_departure_fetcher_spec.rb
+++ b/spec/models/realtime_departure_fetcher_spec.rb
@@ -1,0 +1,127 @@
+require 'rails_helper'
+
+RSpec.describe RealtimeDepartureFetcher do
+  let(:now) { Time.zone.parse("2015-04-23 7:30am") }
+  let(:agency) { create(:agency, :with_rt_endpoint) }
+  let(:stop) { create(:stop, agency: agency) }
+  let(:trip) { create(:trip, agency: agency, service: create(:service, agency: agency, thursday: true)) }
+  subject { RealtimeDepartureFetcher.new(agency, stop, now) }
+
+  describe "#stop_times" do
+    let!(:applicable_stop_time) {
+      create(:stop_time, agency: agency, stop: stop, trip: trip, departure_time: now + 10.minutes)
+    }
+    let!(:out_of_time_range_stop_time) {
+      create(:stop_time, agency: agency, stop: stop, trip: trip, departure_time: now - 2.hours)
+    }
+    let!(:different_service_stop_time) {
+      create(:stop_time, agency: agency, stop: stop, trip: create(:trip, agency: agency), departure_time: now)
+    }
+
+    it "searches stop_times within a time range and on the service" do
+      expect(subject.stop_times).to eq([applicable_stop_time])
+    end
+  end
+
+  describe "#departures" do
+    let(:departure_time) { now + 10.minutes }
+    let!(:stop_time) { create(:stop_time, agency:agency, stop: stop, trip: trip, departure_time: departure_time) }
+    let(:fake_realtime_updates) { double("RealtimeUpdates", for_stop_time: fake_stop_time_update) }
+
+    before do
+      allow(Metro::RealtimeUpdates).to receive(:fetch).with(agency).and_return(fake_realtime_updates)
+    end
+
+    context "when an associated realtime update exists for the stop time" do
+      let(:fake_stop_time_update) { OpenStruct.new(departure_time: now + 15.minutes) }
+
+      it "creates one for each stop_time" do
+        expect(subject.departures.size).to eq(1)
+      end
+
+      it "is realtime" do
+        expect(subject.departures.first).to be_realtime
+      end
+
+      it "applies the departure time from the realtime update" do
+        expect(subject.departures.first.time).to eq(fake_stop_time_update.departure_time)
+      end
+    end
+
+    context "when an associated realtime update does not exist for the stop time" do
+      let(:fake_stop_time_update) { nil }
+
+      it "creates one for each stop_time" do
+        expect(subject.departures.size).to eq(1)
+      end
+
+      it "is not realtime" do
+        expect(subject.departures.first).to_not be_realtime
+      end
+
+      it "applies the departure time the scheduled stop_time" do
+        expect(subject.departures.first.time).to eq(stop_time.departure_time)
+      end
+    end
+
+    context "when a departure is less than 10 minutes past" do
+      let(:departure_time) { now - 9.minutes }
+
+      context "and realtime updates are in the past for the stop time" do
+        let(:fake_stop_time_update) { OpenStruct.new(departure_time: now - 9.minutes) }
+
+        it "it shows already past departures for a short while" do
+          expect(subject.departures.size).to eq(1)
+        end
+      end
+
+      context "and realtime updates do not exist for the stop time" do
+        let(:fake_stop_time_update) { nil }
+
+        it "it shows already past departures for a short while" do
+          expect(subject.departures.size).to eq(1)
+        end
+      end
+    end
+
+    context "when a departure is up to an hour in the past" do
+      let(:departure_time) { now - 55.minutes }
+
+      context "and realtime updates are available showing upcoming departure for the stop time" do
+        let(:fake_stop_time_update) { OpenStruct.new(departure_time: now + 5.minutes) }
+
+        it "it shows late departures up to an hour past due" do
+          expect(subject.departures.size).to eq(1)
+        end
+      end
+
+      context "and realtime updates do not exist for the stop time" do
+        let(:fake_stop_time_update) { nil }
+
+        it "it won't show that stop time" do
+          expect(subject.departures.size).to be_zero
+        end
+      end
+    end
+
+    context "when a departure is more than an hour in the past" do
+      let(:departure_time) { now - 65.minutes }
+
+      context "and realtime updates are available showing upcoming departure for the stop time" do
+        let(:fake_stop_time_update) { OpenStruct.new(departure_time: now + 5.minutes) }
+
+        it "it won't show that stop time" do
+          expect(subject.departures.size).to be_zero
+        end
+      end
+
+      context "and realtime updates do not exist for the stop time" do
+        let(:fake_stop_time_update) { nil }
+
+        it "it won't show that stop time" do
+          expect(subject.departures.size).to be_zero
+        end
+      end
+    end
+  end
+end

--- a/spec/models/stop_spec.rb
+++ b/spec/models/stop_spec.rb
@@ -1,13 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe Stop do
-  describe "#routes" do
-    let(:stop) { create(:stop) }
-    let(:route) { create(:route) }
+  let(:agency) { create(:agency) }
 
-    let!(:trip) { create(:trip, route: route)}
-    let!(:stop_time) { create(:stop_time, stop: stop, trip: trip) }
-    let!(:route_stop) { create(:route_stop, route: route, stop: stop) }
+  describe "#routes" do
+
+    let!(:route_stop) { create(:route_stop) }
+    let(:stop) { route_stop.stop }
+    let(:route) { route_stop.route }
+    let!(:trip) { create(:trip, agency: agency, route: route)}
+    let!(:stop_time) { create(:stop_time, agency: agency, stop: stop, trip: trip) }
 
     it "associates routes to each stop" do
       expect(stop.routes).to eq([route])
@@ -15,7 +17,7 @@ RSpec.describe Stop do
   end
 
   describe "#direction" do
-    let(:stop) { build(:stop, remote_id: remote_id) }
+    let(:stop) { build(:stop, agency: agency, remote_id: remote_id) }
     context "inbound" do
       let(:remote_id) { "8THWALi" }
       specify { expect(stop.direction).to eq("inbound") }

--- a/spec/requests/departures_request_spec.rb
+++ b/spec/requests/departures_request_spec.rb
@@ -2,17 +2,43 @@ require 'rails_helper'
 
 RSpec.describe "departures api" do
   let(:json) { JSON.parse(response.body) }
+  let(:now) { Time.zone.parse("2015-02-16 17:55:00 -0500") }
+  let!(:trip) { create(:trip, agency: agency, remote_id: 940135, service: create(:service, agency: agency, monday: true)) }
+  let!(:stop) { create(:stop, agency: agency, remote_id: "HAMBELi") }
+  let!(:stop_time) { create(:stop_time, agency: agency, stop: stop, trip: trip, departure_time: now + 10.minutes) }
 
-  describe "api/departures" do
-    let(:now) { Time.zone.parse("2015-02-16 17:55:00 -0500") }
-    let!(:trip) { create(:trip, remote_id: 940135, service: create(:service, monday: true)) }
-    let!(:stop) { create(:stop, remote_id: "HAMBELi") }
-    let!(:stop_time) { create(:stop_time, stop: stop, trip: trip, departure_time: now + 10.minutes) }
+  before do
+    fixture = File.read('spec/fixtures/realtime_updates.buf')
+    allow(Metro::Connection).to receive(:get).and_return(fixture)
+  end
 
-    before do
-      fixture = File.read('spec/fixtures/realtime_updates.buf')
-      allow(Metro::Connection).to receive(:get).and_return(fixture)
+  describe "api/departures for agency without realtime data" do
+    let(:agency) { create(:agency) }
+
+    context "with a rails id" do
+      it "returns departures for a given stop" do
+        get "/api/departures/?stop_id=#{stop.id}&time=#{now}"
+        expect(json["data"]["departures"].first["delay"]).to eq(0)
+      end
     end
+
+    context "with a legacy remote_id" do
+      it "returns arrivals for given remote_id" do
+        get "/api/departures/?stop_id=#{stop.remote_id}&time=#{now}"
+        expect(json["data"]["departures"].first["delay"]).to eq(0)
+      end
+    end
+
+    context "missing a stop id" do
+      it "responds with a bad request" do
+        get "/api/departures/?stop_id=&time=#{now}"
+        expect(response).to be_bad_request
+      end
+    end
+  end
+
+  describe "api/departures for agency with realtime data" do
+    let(:agency) { create(:agency, :with_rt_endpoint) }
 
     context "with a rails id" do
       it "returns departures for a given stop" do


### PR DESCRIPTION
Agency already existed as a concept, but was not being used to scope
queries or to figure out the Realtime API to call, etc. Now the code
implicitly uses the Agency from the stop_id passed and limits all of the
relationships to those of the same agency.

Kind of a big commit because it touched a lot of different areas
including how we build our test data.