### PR TITLE
Improve error handling of realtime updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'rails', '~> 4.2.0'
 gem 'active_model_serializers', '~> 0.8.3' # Because people hate 0.9.x branch for the different API, and 0.10.x is built on 0.8
 gem 'geokit-rails' # Provides acts_as_mappable
 gem 'gtfs'         # Support for General Transit Feed Specification (format of the stop/route data)
+gem 'http'
 gem 'pg'
 gem 'puma'
 gem 'rack-cors', require: 'rack/cors'

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'puma'
 gem 'rack-cors', require: 'rack/cors'
 gem 'redis'
 gem 'ruby-protocol-buffers' # Required for parsing GTFS data which is built in protocol buffers
+gem 'sentry-raven'
 
 group :development, :test do
   gem 'byebug'
@@ -31,6 +32,5 @@ end
 
 group :production do
   gem 'rails_12factor'
-  gem 'sentry-raven'
   gem 'uglifier'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    addressable (2.3.8)
     arel (6.0.0)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
@@ -73,6 +74,12 @@ GEM
       multi_json
       rake
       rubyzip (~> 1.1)
+    http (0.8.8)
+      addressable (~> 2.3)
+      http-form_data (~> 1.0.1)
+      http_parser.rb (~> 0.6.0)
+    http-form_data (1.0.1)
+    http_parser.rb (0.6.0)
     i18n (0.7.0)
     json (1.8.2)
     loofah (2.0.2)
@@ -192,6 +199,7 @@ DEPENDENCIES
   factory_girl_rails
   geokit-rails
   gtfs
+  http
   pg
   pry
   pry-byebug

--- a/app/apis/metro/connection.rb
+++ b/app/apis/metro/connection.rb
@@ -2,12 +2,6 @@ require 'uri'
 
 module Metro
   class Connection
-    @open_timeout = 2
-
-    def self.open_timeout=(val)
-      @open_timeout = val
-    end
-
     def self.get(url)
       uri = if url.is_a? URI
               url

--- a/app/apis/metro/connection.rb
+++ b/app/apis/metro/connection.rb
@@ -2,6 +2,11 @@ require 'uri'
 
 module Metro
   class Connection
+    @open_timeout = 2
+
+    def self.open_timeout=(val)
+      @open_timeout = val
+    end
 
     def self.get(url)
       uri = if url.is_a? URI
@@ -10,7 +15,10 @@ module Metro
               URI(url)
             end
 
-      Net::HTTP.get(uri)
+      HTTP.timeout(:global, :write => 1, :connect => 1, :read => 3)
+        .get(uri).to_s
+    rescue HTTP::Error, IOError, Errno::EINVAL, Errno::ECONNRESET
+      raise Metro::Error.new("Failed to get data from: #{uri}")
     end
   end
 end

--- a/app/apis/metro/error.rb
+++ b/app/apis/metro/error.rb
@@ -1,0 +1,4 @@
+module Metro
+  class Error < StandardError
+  end
+end

--- a/app/models/realtime_departure_fetcher.rb
+++ b/app/models/realtime_departure_fetcher.rb
@@ -31,8 +31,8 @@ class RealtimeDepartureFetcher < DepartureFetcher
     unless instance_variable_defined?(:@realtime_updates)
       begin
         @realtime_updates = Metro::RealtimeUpdates.fetch(agency)
-      rescue Timeout::Error, Errno::EINVAL, Errno::ECONNRESET, EOFError,
-        Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError, Net::ProtocolError => e
+      rescue Timeout::Error, Errno::EINVAL, Errno::ECONNRESET, EOFError, Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError, Net::ProtocolError => e
+        Raven.capture_exception(e)
         @realtime_updates = nil
       end
     end

--- a/app/models/realtime_departure_fetcher.rb
+++ b/app/models/realtime_departure_fetcher.rb
@@ -31,7 +31,7 @@ class RealtimeDepartureFetcher < DepartureFetcher
     unless instance_variable_defined?(:@realtime_updates)
       begin
         @realtime_updates = Metro::RealtimeUpdates.fetch(agency)
-      rescue Timeout::Error, Errno::EINVAL, Errno::ECONNRESET, EOFError, Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError, Net::ProtocolError => e
+      rescue Metro::Error => e
         Raven.capture_exception(e)
         @realtime_updates = nil
       end

--- a/app/models/realtime_departure_fetcher.rb
+++ b/app/models/realtime_departure_fetcher.rb
@@ -10,7 +10,7 @@ class RealtimeDepartureFetcher < DepartureFetcher
 
   def departures
     @departures ||= stop_times.map { |stop_time|
-      stop_time_update = realtime_updates.for_stop_time(stop_time)
+      stop_time_update = realtime_updates.for_stop_time(stop_time) if realtime_updates
       Departure.new(stop_time: stop_time, stop_time_update: stop_time_update)
     }.sort_by(&:time).select { |d| active?(d) }
   end
@@ -26,6 +26,17 @@ class RealtimeDepartureFetcher < DepartureFetcher
   end
 
   def realtime_updates
-    @realtime_updates ||= Metro::RealtimeUpdates.fetch(agency)
+    # Non-standard memoization because we want to allow nulls so we don't
+    # continually try and call the service
+    unless instance_variable_defined?(:@realtime_updates)
+      begin
+        @realtime_updates = Metro::RealtimeUpdates.fetch(agency)
+      rescue Timeout::Error, Errno::EINVAL, Errno::ECONNRESET, EOFError,
+        Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError, Net::ProtocolError => e
+        @realtime_updates = nil
+      end
+    end
+
+    @realtime_updates
   end
 end

--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,5 +1,3 @@
-if defined?(Raven)
-  Raven.configure do |config|
-    config.dsn = ENV.fetch("SENTRY_ENDPOINT")
-  end
+Raven.configure do |config|
+  config.environments = ['production']
 end

--- a/spec/apis/metro/connection_spec.rb
+++ b/spec/apis/metro/connection_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe Metro::Connection do
+  subject { Metro::Connection }
+
+  it 'gets data from a URL' do
+    expect(subject.get('https://teamgaslight.com/')).to include('Made with love in')
+  end
+end

--- a/spec/apis/metro/error_spec.rb
+++ b/spec/apis/metro/error_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe Metro::Error do
+  subject do
+    begin
+      begin
+        raise Error
+      rescue
+        raise Metro::Error.new "Testing"
+      end
+    rescue => e
+      e
+    end
+  end
+
+  it 'has a message' do
+    expect(subject.message).to eq("Testing")
+  end
+
+  it 'has a cause' do
+    expect(subject.cause).not_to be_nil
+  end
+end
+

--- a/spec/models/departure_fetcher_spec.rb
+++ b/spec/models/departure_fetcher_spec.rb
@@ -28,17 +28,7 @@ RSpec.describe DepartureFetcher do
     let(:departure_time) { now + 10.minutes }
     let!(:stop_time) { create(:stop_time, agency: agency, stop: stop, trip: trip, departure_time: Interval.for_time(departure_time)) }
 
-    it "creates one for each stop_time" do
-      expect(subject.departures.size).to eq(1)
-    end
-
-    it "is not realtime" do
-      expect(subject.departures.first).to_not be_realtime
-    end
-
-    it "applies the departure time the scheduled stop_time" do
-      expect(subject.departures.first.time).to eq(departure_time)
-    end
+    it_behaves_like "scheduled departures"
 
     context "when a departure is less than 10 minutes past" do
       let(:departure_time) { now - 9.minutes }

--- a/spec/models/realtime_departure_fetcher_spec.rb
+++ b/spec/models/realtime_departure_fetcher_spec.rb
@@ -27,14 +27,12 @@ RSpec.describe RealtimeDepartureFetcher do
     let(:departure_time) { now + 10.minutes }
     let!(:stop_time) { create(:stop_time, agency: agency, stop: stop, trip: trip, departure_time: Interval.for_time(departure_time)) }
 
-    [Timeout::Error, Errno::EINVAL, Errno::ECONNRESET, EOFError, Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError, Net::ProtocolError].each do |error|
-      context "handling #{error}" do
-        before do
-          expect(Metro::RealtimeUpdates).to receive(:fetch).with(agency).and_raise(error)
-        end
-
-        it_behaves_like "scheduled departures"
+    context "handling Metro::Error" do
+      before do
+        expect(Metro::RealtimeUpdates).to receive(:fetch).with(agency).and_raise(Metro::Error)
       end
+
+      it_behaves_like "scheduled departures"
     end
   end
 

--- a/spec/support/shared_examples_for_departure_fetchers.rb
+++ b/spec/support/shared_examples_for_departure_fetchers.rb
@@ -1,0 +1,13 @@
+RSpec.shared_examples 'scheduled departures' do
+  it "creates one for each stop_time" do
+    expect(subject.departures.size).to eq(1)
+  end
+
+  it "is not realtime" do
+    expect(subject.departures.first).to_not be_realtime
+  end
+
+  it "applies the departure time the scheduled stop_time" do
+    expect(subject.departures.first.time).to eq(departure_time)
+  end
+end


### PR DESCRIPTION
Bring back HTTP gem because Net::HTTP timeout handling is the pits.  Introduce
a custom Exception to encapsulate details of Connection failures. Capture HTTP
errors with Sentry still. Lower timeouts so that RT data failures don’t slow
down API.