### PR TITLE
Cache api calls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'pg'
 gem 'puma'
 gem 'rack-cors', require: 'rack/cors'
 gem 'redis'
+gem 'redis-rails'           # For using Redis as the application cache
 gem 'ruby-protocol-buffers' # Required for parsing GTFS data which is built in protocol buffers
 gem 'sentry-raven'
 gem 'kaminari'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,6 +142,22 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rake (10.4.2)
     redis (3.2.1)
+    redis-actionpack (4.0.0)
+      actionpack (~> 4)
+      redis-rack (~> 1.5.0)
+      redis-store (~> 1.1.0)
+    redis-activesupport (4.0.0)
+      activesupport (~> 4)
+      redis-store (~> 1.1.0)
+    redis-rack (1.5.0)
+      rack (~> 1.5)
+      redis-store (~> 1.1.0)
+    redis-rails (4.0.0)
+      redis-actionpack (~> 4)
+      redis-activesupport (~> 4)
+      redis-store (~> 1.1.0)
+    redis-store (1.1.4)
+      redis (>= 2.2)
     rspec-core (3.2.3)
       rspec-support (~> 3.2.0)
     rspec-expectations (3.2.1)
@@ -212,6 +228,7 @@ DEPENDENCIES
   rails (~> 4.2.0)
   rails_12factor
   redis
+  redis-rails
   rspec-rails
   ruby-protocol-buffers
   sentry-raven

--- a/app/apis/metro/cacheable_connection.rb
+++ b/app/apis/metro/cacheable_connection.rb
@@ -1,0 +1,9 @@
+module Metro
+  class CacheableConnection
+    def self.get(url, key, cache_opts)
+      Rails.cache.fetch(key, cache_opts) do
+        Connection.get(url)
+      end
+    end
+  end
+end

--- a/app/apis/metro/cacheable_connection.rb
+++ b/app/apis/metro/cacheable_connection.rb
@@ -2,6 +2,7 @@ module Metro
   class CacheableConnection
     def self.get(url, key, cache_opts)
       Rails.cache.fetch(key, cache_opts) do
+        Rails.logger.warn("Cache expired, fetching: #{url}")
         Connection.get(url)
       end
     end

--- a/app/apis/metro/realtime_updates.rb
+++ b/app/apis/metro/realtime_updates.rb
@@ -8,14 +8,13 @@ module Metro
       race_condition_ttl: 15
     }
 
-    def initialize(agency)
-     @url = agency.gtfs_trip_updates_url
+    def self.fetch(agency)
+     url = agency.gtfs_trip_updates_url
+     new(CacheableConnection.get(url, "rt_trips:#{url}", CACHE_OPTS))
     end
 
-    def fetch
-      buffer = CacheableConnection.get(@url, "rt_trips:#{@url}", CACHE_OPTS)
+    def initialize(buffer)
       @feed = TransitRealtime::FeedMessage.parse(buffer)
-      self
     rescue ProtocolBuffers::DecodeError
       raise Metro::Error.new "Problem parsing feed"
     end

--- a/app/models/realtime_departure_fetcher.rb
+++ b/app/models/realtime_departure_fetcher.rb
@@ -32,6 +32,7 @@ class RealtimeDepartureFetcher < DepartureFetcher
       begin
         @realtime_updates = Metro::RealtimeUpdates.new(agency).fetch
       rescue Metro::Error => e
+        Rails.logger.warn(e)
         Raven.capture_exception(e)
         @realtime_updates = nil
       end

--- a/app/models/realtime_departure_fetcher.rb
+++ b/app/models/realtime_departure_fetcher.rb
@@ -30,7 +30,7 @@ class RealtimeDepartureFetcher < DepartureFetcher
     # continually try and call the service
     unless instance_variable_defined?(:@realtime_updates)
       begin
-        @realtime_updates = Metro::RealtimeUpdates.fetch(agency)
+        @realtime_updates = Metro::RealtimeUpdates.new(agency).fetch
       rescue Metro::Error => e
         Raven.capture_exception(e)
         @realtime_updates = nil

--- a/app/models/realtime_departure_fetcher.rb
+++ b/app/models/realtime_departure_fetcher.rb
@@ -30,7 +30,7 @@ class RealtimeDepartureFetcher < DepartureFetcher
     # continually try and call the service
     unless instance_variable_defined?(:@realtime_updates)
       begin
-        @realtime_updates = Metro::RealtimeUpdates.new(agency).fetch
+        @realtime_updates = Metro::RealtimeUpdates.fetch(agency)
       rescue Metro::Error => e
         Rails.logger.warn(e)
         Raven.capture_exception(e)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,4 +38,8 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Temporarily enable caching in development (COMMENT OUT WHEN DONE!)
+  # config.action_controller.perform_caching = true
+  # config.cache_store = :redis_store, ENV.fetch('REDISTOGO_URL')
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -55,7 +55,7 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :redis_store, ENV['REDISTOGO_URL']
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'

--- a/spec/apis/metro/realtime_updates_spec.rb
+++ b/spec/apis/metro/realtime_updates_spec.rb
@@ -4,15 +4,15 @@ require 'protocol_buffers'
 RSpec.describe Metro::RealtimeUpdates do
   let(:fixture) { File.read('spec/fixtures/realtime_updates.buf') }
   let(:agency) { create(:agency, :with_rt_endpoint) }
-  subject { Metro::RealtimeUpdates.new(agency) }
+  subject { Metro::RealtimeUpdates.new(fixture) }
 
   before do
     allow(Metro::Connection).to receive(:get).with(agency.gtfs_trip_updates_url).and_return(fixture)
-    subject.fetch
   end
 
   describe "#fetch" do
     it "calls Connection.get with the endpoint" do
+      Metro::RealtimeUpdates.fetch(agency)
       expect(Metro::Connection).to have_received(:get).with(agency.gtfs_trip_updates_url)
     end
   end
@@ -76,7 +76,7 @@ RSpec.describe Metro::RealtimeUpdates do
     end
 
     it 'throws a Metro::Error' do
-      expect { subject.fetch }.to raise_error(Metro::Error)
+      expect { Metro::RealtimeUpdates.new(fixture) }.to raise_error(Metro::Error)
     end
   end
 end

--- a/spec/apis/metro/realtime_updates_spec.rb
+++ b/spec/apis/metro/realtime_updates_spec.rb
@@ -3,14 +3,16 @@ require 'protocol_buffers'
 
 RSpec.describe Metro::RealtimeUpdates do
   let(:fixture) { File.read('spec/fixtures/realtime_updates.buf') }
-  subject { Metro::RealtimeUpdates.new(fixture) }
+  let(:agency) { create(:agency, :with_rt_endpoint) }
+  subject { Metro::RealtimeUpdates.new(agency) }
+
+  before do
+    allow(Metro::Connection).to receive(:get).with(agency.gtfs_trip_updates_url).and_return(fixture)
+    subject.fetch
+  end
 
   describe "#fetch" do
-    let(:agency) { create(:agency, :with_rt_endpoint) }
-
     it "calls Connection.get with the endpoint" do
-      allow(Metro::Connection).to receive(:get).with(agency.gtfs_trip_updates_url).and_return(fixture)
-      Metro::RealtimeUpdates.fetch(agency)
       expect(Metro::Connection).to have_received(:get).with(agency.gtfs_trip_updates_url)
     end
   end
@@ -74,7 +76,7 @@ RSpec.describe Metro::RealtimeUpdates do
     end
 
     it 'throws a Metro::Error' do
-      expect { subject.new(fixture) }.to raise_error(Metro::Error)
+      expect { subject.fetch }.to raise_error(Metro::Error)
     end
   end
 end

--- a/spec/models/realtime_departure_fetcher_spec.rb
+++ b/spec/models/realtime_departure_fetcher_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe RealtimeDepartureFetcher do
 
     context "handling Metro::Error" do
       before do
-        expect(Metro::RealtimeUpdates).to receive(:fetch).with(agency).and_raise(Metro::Error)
+        allow_any_instance_of(Metro::RealtimeUpdates).to receive(:fetch).and_raise(Metro::Error)
       end
 
       it_behaves_like "scheduled departures"
@@ -42,7 +42,7 @@ RSpec.describe RealtimeDepartureFetcher do
     let(:fake_realtime_updates) { double("RealtimeUpdates", for_stop_time: fake_stop_time_update) }
 
     before do
-      allow(Metro::RealtimeUpdates).to receive(:fetch).with(agency).and_return(fake_realtime_updates)
+      allow_any_instance_of(Metro::RealtimeUpdates).to receive(:fetch).and_return(fake_realtime_updates)
     end
 
     context "when an associated realtime update exists for the stop time" do

--- a/spec/models/realtime_departure_fetcher_spec.rb
+++ b/spec/models/realtime_departure_fetcher_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe RealtimeDepartureFetcher do
 
     context "handling Metro::Error" do
       before do
-        allow_any_instance_of(Metro::RealtimeUpdates).to receive(:fetch).and_raise(Metro::Error)
+        allow(Metro::RealtimeUpdates).to receive(:fetch).and_raise(Metro::Error)
       end
 
       it_behaves_like "scheduled departures"
@@ -42,7 +42,7 @@ RSpec.describe RealtimeDepartureFetcher do
     let(:fake_realtime_updates) { double("RealtimeUpdates", for_stop_time: fake_stop_time_update) }
 
     before do
-      allow_any_instance_of(Metro::RealtimeUpdates).to receive(:fetch).and_return(fake_realtime_updates)
+      allow(Metro::RealtimeUpdates).to receive(:fetch).and_return(fake_realtime_updates)
     end
 
     context "when an associated realtime update exists for the stop time" do


### PR DESCRIPTION
CachableConnection to cache the results of external API calls using our Redis store. Should reduce the load on the Metro server a bit, deal with some minor outages a bit better, and overall improve performance when a bunch of users are using the app.

Expires in 15 seconds.
race_time_ttl will continue to serve up old data to new requests for up to 15 additional seconds to prevent them from blocking and/or requesting the same data again.

@rockwood For your review.